### PR TITLE
fix: resolve sketch-module-* packages via require.resolve

### DIFF
--- a/lib/utils/webpackConfig.js
+++ b/lib/utils/webpackConfig.js
@@ -63,12 +63,12 @@ module.exports = function (program, output, manifestFolder, packageJSON) {
     if (commandIdentifier) {
       plugins.push(
         new webpack.ProvidePlugin({
-          'console': 'sketch-module-console-polyfill',
-          'fetch': 'sketch-module-fetch-polyfill',
-          'setTimeout': ['sketch-module-settimeout-polyfill', 'setTimeout'],
-          'clearTimeout': ['sketch-module-settimeout-polyfill', 'clearTimeout'],
-          'setInterval': ['sketch-module-setinterval-polyfill', 'setInterval'],
-          'clearInterval': ['sketch-module-setinterval-polyfill', 'clearInterval']
+          'console': require.resolve('sketch-module-console-polyfill'),
+          'fetch': require.resolve('sketch-module-fetch-polyfill'),
+          'setTimeout': [require.resolve('sketch-module-settimeout-polyfill'), 'setTimeout'],
+          'clearTimeout': [require.resolve('sketch-module-settimeout-polyfill'), 'clearTimeout'],
+          'setInterval': [require.resolve('sketch-module-setinterval-polyfill'), 'setInterval'],
+          'clearInterval': [require.resolve('sketch-module-setinterval-polyfill'), 'clearInterval']
         })
       )
     }


### PR DESCRIPTION
* deals with `Module not found: Error: Can't resolve 'sketch-module-console-polyfill'` in setups where `skpm` is linked into the using project.
* related: https://github.com/airbnb/react-sketchapp/pull/53#issuecomment-302450012